### PR TITLE
Changed to use Update Values and rpaframework 9.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,4 @@ The robot is split in to two main files: `tasks.robot` and `AitoRFHelper.py`. Fo
 1. First task is **Upload data** that pulls the dataset from our public S3 bucket. If the table does not yet exist in your Aito instance, it will upload the data in.
 2. Second task is **Label invoices** which will read the Google Sheet file row by row, and make a prediction using Aito, and then fill in the results for each row. The filled values are the predicted GL code ("feature"), the confidence, and either FALSE or TRUE if the row needs a manual review, based on the set confidence `${threshold}`.
 
-NOTE: GCP has ratelimits especially for Sheet write operations. If you are getting errors, start by checking what rate limits apply to you. Add a sleep in Keyword `Predict GL With Aito` for-loop if the per minute rates are exceeded.
-
 **Contact:** Best way to reach us is through our [Slack group](https://aito.ai/join-slack/). Feeback would be awesome! <3

--- a/conda.yaml
+++ b/conda.yaml
@@ -5,5 +5,5 @@ dependencies:
   - python=3.7.5
   - pip=20.1
   - pip:
-    - rpaframework[google]==7.5.0
+    - rpaframework[google]==9.4.0
     - aitoai==0.4.1

--- a/tasks.robot
+++ b/tasks.robot
@@ -4,6 +4,7 @@ Library         RPA.Cloud.Google
 Library         RPA.HTTP
 Library         AitoRFHelper
 Library         Collections
+Library         Dialogs
 Library         aito.api
 Library         aito.client.AitoClient    ${AITO_API_URL}    ${AITO_API_KEY}    False    WITH NAME    aito_client
 Suite Setup     Init Sheets Client    service_account.json
@@ -13,10 +14,7 @@ ${trainingFile}         invoice_train.csv
 ${tableName}            roboc_invoices
 ${predictField}         GL_Code
 ${threshold}            0.8
-${SHEET_RANGE}          Sheet1!A2:E51
-${WRITE_RANGE}          Sheet1!F
-${row_nr}               2
-${increment}            1
+${SHEET_RANGE}          Sheet1!A2:H51
 
 *** Keywords ***
 Download Sample Data
@@ -31,24 +29,6 @@ Upload Training Data
     Run Keyword Unless    ${tableExists}    Create Table    client=${client}    table_name=${tableName}     schema=${schema}
     Run Keyword Unless    ${tableExists}    aito.api.Upload Entries    ${client}    ${tableName}    ${entryData}
 
-*** Keywords ***
-Make List
-    [Arguments]     ${feature}    ${confidence}
-    ${result}=      BuiltIn.Evaluate        ${confidence} <= ${threshold}
-    ${list}=        Create List             ${feature}          ${confidence}       ${result}
-    [Return]        ${list}      
-
-*** Keywords ***
-Predict GL With Aito
-    [Arguments]     ${client}     ${predictQuery}        ${inputData}
-    FOR    ${inputRow}    IN    @{inputData["values"]}
-        &{result}=       Predict Row     ${client}       ${inputRow}    ${predictQuery}
-        ${values}=       Make List       ${result}[feature]      ${result}[confidence]
-        ${write_row}=    Catenate        SEPARATOR=      ${WRITE_RANGE}      ${row_nr} 
-        Insert Values    ${G_SHEET_ID}     ${write_row}    ${values}
-        ${row_nr}=       BuiltIn.Evaluate        ${row_nr} + ${increment}  
-    END
-
 *** Tasks ***
 Upload data
     Download Sample Data
@@ -58,9 +38,16 @@ Upload data
 
 *** Tasks ***
 Label invoices
-    ${spreadsheet_content}=    Get Values
-    ...    ${G_SHEET_ID}
-    ...    ${SHEET_RANGE}
     ${client}    Get Library Instance    aito_client
     ${predictQuery}    ${evaluateQuery}=    Quick Predict And Evaluate    ${client}    ${table_name}     ${predictField}
-    Predict GL With Aito     ${client}    ${predictQuery}    ${spreadsheet_content}   
+    ${sheet}=    Get Values     ${G_SHEET_ID}      ${SHEET_RANGE}
+    ${values}    Set Variable    ${sheet}[values][0:]
+    FOR    ${row}    IN    @{values}
+        &{aitoresult}=    Predict Row       ${client}       ${row}    ${predictQuery}
+        ${review}=        BuiltIn.Evaluate  ${aitoresult}[confidence] <= ${threshold}
+        Append To List    ${row}     ${aitoresult}[feature] 
+        Append To List    ${row}     ${aitoresult}[confidence]
+        Append To List    ${row}     ${review}
+    END
+    ${response}=    Update Values    ${G_SHEET_ID}    ${SHEET_RANGE}    ${sheet}[values]
+    Log Many    ${response}


### PR DESCRIPTION
Changed the G Sheet writing to use the new `Update Values` instead of slow `Insert Values`, which also had issues with API call thresholds. Now all the Aito queries happen first consecutively, and only after all rows have been gone through they are written to G Sheet in one operation.

Additionally code was refactored by removing the separate Keyword for `Predict GL With Aito` and moving the functionality to the Task.